### PR TITLE
57 fix edit feature

### DIFF
--- a/src/main/java/use_cases/add_edit_category_use_case/CategoryUCI.java
+++ b/src/main/java/use_cases/add_edit_category_use_case/CategoryUCI.java
@@ -61,6 +61,14 @@ public class CategoryUCI implements CategoryIB {
             CategoryOD categoryODSuccessAdd = new CategoryOD("You have added a new category!");
             return categoryOB.success(categoryODSuccessAdd);
 
+        } catch (NoSuchElementException e) {
+            //NoSuchElementException: User tries to edit a category but did not select a category in EditCategoryV.
+            //This exception for an EditCategoryUseCase is caught here due to the implementation in CategoryC.
+            //The determining factor for entering an Add or Edit UseCase is by checking if the selectedCategory is null,
+            // hence when a user did not select a category when editing a category, CategoryC actually classifies the instance
+            // as an AddCategoryUseCase although the user is interacting with the editCategoryView.
+            CategoryOD categoryODFailEdit = new CategoryOD("Please select a Category that you wish to edit!");
+            return categoryOB.fail(categoryODFailEdit);
         } catch(NumberFormatException|NullPointerException e){
             //NumberFormatException|NullPointerException: User tries to add a new budget value that can not be converted to a double.
             CategoryOD categoryODFailAdd = new CategoryOD("Category budget needs to be a number. Please try again!");
@@ -105,10 +113,6 @@ public class CategoryUCI implements CategoryIB {
             CategoryOD categoryODSuccessEdit = new CategoryOD("You have edited a category!");
             return categoryOB.success(categoryODSuccessEdit);
 
-        } catch (NoSuchElementException e) {
-            //NoSuchElementException: User tries to edit a category that does not exist.
-            CategoryOD categoryODFailEdit = new CategoryOD("There is no such category in the current month. Please add a new category or select existing category!");
-            return categoryOB.fail(categoryODFailEdit);
         } catch(NumberFormatException|NullPointerException e){
             //NumberFormatException|NullPointerException: User tries to edit a budget value with input that can not be converted to a double.
             CategoryOD categoryODFailEdit = new CategoryOD("Category budget needs to be a number. Please try again!");

--- a/src/main/java/use_cases/add_edit_category_use_case/CategoryUCI.java
+++ b/src/main/java/use_cases/add_edit_category_use_case/CategoryUCI.java
@@ -61,14 +61,6 @@ public class CategoryUCI implements CategoryIB {
             CategoryOD categoryODSuccessAdd = new CategoryOD("You have added a new category!");
             return categoryOB.success(categoryODSuccessAdd);
 
-        } catch (NoSuchElementException e) {
-            //NoSuchElementException: User tries to edit a category but did not select a category in EditCategoryV.
-            //This exception for an EditCategoryUseCase is caught here due to the implementation in CategoryC.
-            //The determining factor for entering an Add or Edit UseCase is by checking if the selectedCategory is null,
-            // hence when a user did not select a category when editing a category, CategoryC actually classifies the instance
-            // as an AddCategoryUseCase although the user is interacting with the editCategoryView.
-            CategoryOD categoryODFailEdit = new CategoryOD("Please select a Category that you wish to edit!");
-            return categoryOB.fail(categoryODFailEdit);
         } catch(NumberFormatException|NullPointerException e){
             //NumberFormatException|NullPointerException: User tries to add a new budget value that can not be converted to a double.
             CategoryOD categoryODFailAdd = new CategoryOD("Category budget needs to be a number. Please try again!");

--- a/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
+++ b/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
@@ -79,15 +79,7 @@ public class ExpenseUCI implements ExpenseIB {
         } catch (EntityException e) {
             // EntityException fail: User tries to add an invalid Expense name but failed. (See entities/EntityException.java)
             ExpenseOD expenseODFailAdd = new ExpenseOD("There is already a expense with this new name in this month.");
-            return expenseOB.fail(expenseODFailAdd);
-        } catch(NoSuchElementException e){
-            // NoSuchElementException fail: User tries to edit an expense but did not select an expense in editExpenseView.
-            //This exception for an EditExpenseUseCase is caught here due to the implementation in ExpenseC.
-            //The determining factor for entering an Add or Edit UseCase is by checking if the selected Expense is null,
-            // hence when a user did not select an expense when editing an expense, ExpenseC actually classifies the instance
-            // as an AddExpenseUseCase although the user is interacting with the editExpenseView.
-        ExpenseOD expenseODFailEdit = new ExpenseOD("Please select an expense you wish to edit.");
-        return expenseOB.fail(expenseODFailEdit);}}
+            return expenseOB.fail(expenseODFailAdd);}}
 
     /**
      * Attempts to edit an expense with information from ExpenseID and returns a ExpenseOD indicating whether fail/success after execution.

--- a/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
+++ b/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
@@ -81,8 +81,12 @@ public class ExpenseUCI implements ExpenseIB {
             ExpenseOD expenseODFailAdd = new ExpenseOD("There is already a expense with this new name in this month.");
             return expenseOB.fail(expenseODFailAdd);
         } catch(NoSuchElementException e){
-        // NoSuchElementException fail: User tries to assign a category that does not exist in current month.
-        ExpenseOD expenseODFailEdit = new ExpenseOD("There is no such category in the current month. Please add a new category or select existing category!");
+            // NoSuchElementException fail: User tries to edit an expense but did not select an expense in editExpenseView.
+            //This exception for an EditExpenseUseCase is caught here due to the implementation in ExpenseC.
+            //The determining factor for entering an Add or Edit UseCase is by checking if the selected Expense is null,
+            // hence when a user did not select an expense when editing an expense, ExpenseC actually classifies the instance
+            // as an AddExpenseUseCase although the user is interacting with the editExpenseView.
+        ExpenseOD expenseODFailEdit = new ExpenseOD("Please select an expense you wish to edit.");
         return expenseOB.fail(expenseODFailEdit);}}
 
     /**
@@ -136,7 +140,7 @@ public class ExpenseUCI implements ExpenseIB {
 
             } catch(NoSuchElementException e){
                 //NoSuchElementException fail: User tries to edit an expense that does not exist.
-                ExpenseOD expenseODFailEdit = new ExpenseOD("There is no such expense in the current month. Please add a new expense or select existing expense!");
+                ExpenseOD expenseODFailEdit = new ExpenseOD("Please make sure you have selected the expense you wish to edit or assigned a category to the expense!");
                 return expenseOB.fail(expenseODFailEdit);
             } catch(NumberFormatException e){
                 // NumberFormatException|NullPointerException fail: User tries to edit Expense value to an invalid number.

--- a/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
+++ b/src/main/java/use_cases/add_edit_expenses_use_case/ExpenseUCI.java
@@ -9,8 +9,6 @@ import java.util.Objects;
 public class ExpenseUCI implements ExpenseIB {
     private final ExpenseOB expenseOB;
     private ExpenseID expenseID;
-    private ArrayList<Expense> recurringExpenseList;
-
     /**
      * Constructs ExpenseUCI.
      *
@@ -45,7 +43,6 @@ public class ExpenseUCI implements ExpenseIB {
         MonthlyStorage month = expenseIDAdd.getSession().getMonthlyData(expenseIDAdd.getMonthID());
         ArrayList<Expense> monthExpenseList = month.getExpenseData();
         ArrayList<Category> categoryList = month.getCategoryData();
-        this.recurringExpenseList = session.getRecurData();
 
         try {double valueDouble = toDouble(expenseIDAdd.getValue());
             Category selectedCategory = findCategory(categoryList, expenseID.getCategory());
@@ -110,19 +107,19 @@ public class ExpenseUCI implements ExpenseIB {
                     // Repeated name fail: When a user tries to edit the expense name to a existing expense in month.
                     ExpenseOD expenseODFailEdit = new ExpenseOD("There is already a expense with this new name in this month.");
                     return expenseOB.fail(expenseODFailEdit);}}
-
             if (changeInRecurringInfo()) {
                 if (expenseID.getIsRecurringExpense()) {
-                    setEditInfo(expenseID, valueDouble, selectedExpense,selectedCategory);
+                    setEditInfo(expenseID, valueDouble, selectedExpense, selectedCategory);
                     session.addRecurExpense(selectedExpense);
                     // Success edit to new recurring expense.
-                    ExpenseOD expenseODSuccessEditRecurring = new ExpenseOD("You have updated all changes of this new recurring expense!");
+                    ExpenseOD expenseODSuccessEditRecurring = new ExpenseOD("You have updated all changes of this recurring expense!");
                     return expenseOB.success(expenseODSuccessEditRecurring);
                 }else{
                     setEditInfo(expenseID, valueDouble, selectedExpense,selectedCategory);
-                    session.deleteRecurExpense(expenseID.getName());
+                    session.deleteRecurExpense(selectedExpense.getName());
                     //Success edit to remove recurring expense.
-                    ExpenseOD expenseODSuccessEditRecurring = new ExpenseOD("You have updated all changes of this expense and it is no longer a recurring expense!");
+                    ExpenseOD expenseODSuccessEditRecurring = new ExpenseOD("You have updated all changes of " +
+                            "this expense and it is no longer a recurring expense!");
                     return expenseOB.success(expenseODSuccessEditRecurring);}
             }else{setEditInfo(expenseID, valueDouble, selectedExpense,selectedCategory);}
 
@@ -132,7 +129,8 @@ public class ExpenseUCI implements ExpenseIB {
 
             } catch(NoSuchElementException e){
                 //NoSuchElementException fail: User tries to edit an expense that does not exist.
-                ExpenseOD expenseODFailEdit = new ExpenseOD("Please make sure you have selected the expense you wish to edit or assigned a category to the expense!");
+                ExpenseOD expenseODFailEdit = new ExpenseOD("Please make sure you have selected the expense you " +
+                        "wish to edit or assigned a category to the expense!");
                 return expenseOB.fail(expenseODFailEdit);
             } catch(NumberFormatException e){
                 // NumberFormatException|NullPointerException fail: User tries to edit Expense value to an invalid number.
@@ -148,9 +146,9 @@ public class ExpenseUCI implements ExpenseIB {
      * @throws NoSuchElementException thrown when couldn't find Expense with String name.
      */
         public Expense findExpense(ArrayList<Expense> expenseData, String name)throws NoSuchElementException{
-            if(expenseData != null) {
+            if(!expenseData.isEmpty()) {
                 for (Expense expense : expenseData) {
-                    if (Objects.equals(expense.getName(), name)) {
+                    if (expense.getName().equals(name)) {
                         return expense;}}
             }
             throw new NoSuchElementException();}
@@ -185,11 +183,11 @@ public class ExpenseUCI implements ExpenseIB {
      */
     private boolean changeInRecurringInfo() {
         if(expenseID.getIsRecurringExpense()) {
-            try {findExpense(recurringExpenseList, expenseID.getOldExpense());
+            try {findExpense(expenseID.getSession().getRecurData(), expenseID.getOldExpense());
                 return false;
             }catch (NoSuchElementException e){return true;}
         }else{
-            try{findExpense(recurringExpenseList, expenseID.getOldExpense());
+            try{findExpense(expenseID.getSession().getRecurData(), expenseID.getOldExpense());
                 return true;
             }catch(NoSuchElementException e) {
                 return false;}}}

--- a/src/main/java/views/add_edit_category_views/EditCategoryV.java
+++ b/src/main/java/views/add_edit_category_views/EditCategoryV.java
@@ -116,14 +116,18 @@ public class EditCategoryV extends JFrame implements ActionListener, LoadMonthMe
      * Pop-up window with context specific message may be shown to user.
      */
     private void tryUseCaseEdit(){
+        CategoryOD message;
+        message = null;
         try {
-            CategoryOD message = controller.categoryInMonth(nameInput.getText(), String.valueOf(budgetInput.getText()), monthID, currSession, selectedCategory);
-            JOptionPane.showMessageDialog(this, message.getMessage());
+            message = controller.categoryInMonth(nameInput.getText(), String.valueOf(budgetInput.getText()), monthID,
+                    currSession, selectedCategory);
             frame.setVisible(false);
             // Update Month Menu
             loadMonthMenu(currSession,monthID,null);
         } catch (EntityException e) {
-            JOptionPane.showMessageDialog(this, "This month does not exist in current session. Please go to add month page.");
-        }
+            JOptionPane.showMessageDialog(this, "This month does not exist in current session. " +
+                    "Please go to add month page.");
+        }if (message != null) {
+            JOptionPane.showMessageDialog(this, message.getMessage());}
     }
 }

--- a/src/main/java/views/add_edit_category_views/EditCategoryV.java
+++ b/src/main/java/views/add_edit_category_views/EditCategoryV.java
@@ -87,8 +87,9 @@ public class EditCategoryV extends JFrame implements ActionListener, LoadMonthMe
         //Two ActionListeners with different behaviours differentiated by checking evt.getSource().
         if (evt.getSource() == categoryCombo) {
             this.selectedCategory = (String) categoryCombo.getSelectedItem();
-        }
-        else {
+        } else if(categoryCombo.getSelectedIndex() == -1){
+            JOptionPane.showMessageDialog( this, "Please select a category you wish to edit.");
+        } else {
             // Check if user inputs a category name.
             if (nameInput.getText().isEmpty()) {
                 JOptionPane.showMessageDialog( this, "Please enter the previous category name if you don't wish to edit. Thanks.");
@@ -97,16 +98,11 @@ public class EditCategoryV extends JFrame implements ActionListener, LoadMonthMe
             else if (budgetInput.getText().isEmpty()){
                 JOptionPane.showMessageDialog(this,"Please enter the previous category budget if you don't wish to edit. Thanks.");
             }
-            // Check if user selects an old category.
-            else if (categoryCombo.getSelectedItem() == null) {
-                JOptionPane.showMessageDialog( this, "Please select a category to edit.");
-            }
             else {
                 tryUseCaseEdit();
             }
         }
     }
-
     /**
      * Load Month Menu and notify user if opening Month Menu of a new MonthlyStorage created.
      *

--- a/src/main/java/views/add_edit_category_views/EditCategoryV.java
+++ b/src/main/java/views/add_edit_category_views/EditCategoryV.java
@@ -87,20 +87,16 @@ public class EditCategoryV extends JFrame implements ActionListener, LoadMonthMe
         //Two ActionListeners with different behaviours differentiated by checking evt.getSource().
         if (evt.getSource() == categoryCombo) {
             this.selectedCategory = (String) categoryCombo.getSelectedItem();
-        } else if(categoryCombo.getSelectedIndex() == -1){
+        } else if(selectedCategory == null){
             JOptionPane.showMessageDialog( this, "Please select a category you wish to edit.");
-        } else {
-            // Check if user inputs a category name.
-            if (nameInput.getText().isEmpty()) {
-                JOptionPane.showMessageDialog( this, "Please enter the previous category name if you don't wish to edit. Thanks.");
-            }
-            // Check if user inputs a category budget.
-            else if (budgetInput.getText().isEmpty()){
-                JOptionPane.showMessageDialog(this,"Please enter the previous category budget if you don't wish to edit. Thanks.");
-            }
-            else {
-                tryUseCaseEdit();
-            }
+        } else if(evt.getSource() == submit){
+            if (nameInput.getText().isEmpty()) {// Check if user inputs a category name.
+                JOptionPane.showMessageDialog( this, "Please enter the previous category name if " +
+                        "you don't wish to edit. Thanks.");
+            } else if (budgetInput.getText().isEmpty()){// Check if user inputs a category budget.
+                JOptionPane.showMessageDialog(this,"Please enter the previous category budget if " +
+                        "you don't wish to edit. Thanks.");
+            } else {tryUseCaseEdit();}
         }
     }
     /**

--- a/src/main/java/views/add_edit_epense_views/AddExpenseV.java
+++ b/src/main/java/views/add_edit_epense_views/AddExpenseV.java
@@ -99,8 +99,6 @@ public class AddExpenseV extends JFrame implements ActionListener, LoadMonthMenu
             message = null;
             try {
                 message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory, isRecurring, monthID, currSession, selectedExpense);
-//                JOptionPane.showMessageDialog(this, message.getMessage());
-//                 Update Month Menu
                 frame.setVisible(false);
                 loadMonthMenu(currSession,monthID,null);
             } catch (EntityException e) {
@@ -109,7 +107,6 @@ public class AddExpenseV extends JFrame implements ActionListener, LoadMonthMenu
                 JOptionPane.showMessageDialog(this, message.getMessage());
         }}
     }
-
     /**
      * Load Month Menu and notify user if opening Month Menu of a new MonthlyStorage created.
      *

--- a/src/main/java/views/add_edit_epense_views/EditExpenseV.java
+++ b/src/main/java/views/add_edit_epense_views/EditExpenseV.java
@@ -23,10 +23,8 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
     private final JComboBox<String> categoryCombo;
     private final JTextField nameInput;
     private final JTextField valueInput;
-    private String selectedCategory;
     private String selectedExpense;
     private final JCheckBox isRecurringCheckBox = new JCheckBox("Is recurring expense.");
-    private boolean isRecurring;
     private final JButton submit = new JButton("Submit");
     private final int monthID;
     private final SessionStorage currSession;
@@ -41,7 +39,8 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
      * @param monthID int representing the MonthlyStorage.
      * @param currSession SessionStorage the current working session.
      */
-    public EditExpenseV(MonthMenuV monthMenu, ExpenseC controller, String[] existingExpense, String[] existingCategory, int monthID, SessionStorage currSession) {
+    public EditExpenseV(MonthMenuV monthMenu, ExpenseC controller, String[] existingExpense, String[] existingCategory,
+                        int monthID, SessionStorage currSession) {
         this.monthMenu = monthMenu;
         this.controller = controller;
         this.monthID = monthID;
@@ -91,7 +90,6 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
 
         submit.addActionListener(this);
         expenseCombo.addActionListener(this);
-        isRecurringCheckBox.addActionListener(this);
     }
     /**
      * Checks and formats user input to pass in valid parameters to start a use case.
@@ -102,22 +100,25 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
             this.selectedExpense = (String) expenseCombo.getSelectedItem();
             for (Expense recurExpense : currSession.getRecurData()) {
                 if (recurExpense.getName().equals(selectedExpense)) {
+                    // Set isRecurringCheckBox checked if the expense being edited was a recurring expense
                     isRecurringCheckBox.setSelected(true);}}
-        // Set isRecurringCheckBox checked if the expense being edited was a recurring expense
-        this.selectedCategory = (String) categoryCombo.getSelectedItem();
-        this.isRecurring = isRecurringCheckBox.isSelected();
-        }else if(expenseCombo.getSelectedIndex() == -1){
-            JOptionPane.showMessageDialog( this, "Please select an expense you wish to edit.");}
+        }
 
-        if(evt.getSource() == submit){
+        if(selectedExpense == null){
+            JOptionPane.showMessageDialog( this, "Please select an expense you wish to edit.");
+        }else if(evt.getSource() == submit){
+            String selectedCategory = (String) categoryCombo.getSelectedItem();
+            boolean isRecurring = isRecurringCheckBox.isSelected();
             ExpenseOD message = null;
             try {
-                message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory, isRecurring, monthID, currSession, selectedExpense);
+                message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory,
+                        isRecurring, monthID, currSession, selectedExpense);
                 // Update Month Menu
-                this.setVisible(false);
+                frame.setVisible(false);
                 loadMonthMenu(currSession,monthID,null);
             } catch (EntityException e) {
-                JOptionPane.showMessageDialog( this, "This month does not exist in current session. Please go to add month page.");}
+                JOptionPane.showMessageDialog( this, "This month does not exist in current " +
+                        "session. Please go to add month page.");}
             if(message != null){
                 JOptionPane.showMessageDialog( this, message.getMessage());}
         }

--- a/src/main/java/views/add_edit_epense_views/EditExpenseV.java
+++ b/src/main/java/views/add_edit_epense_views/EditExpenseV.java
@@ -105,32 +105,34 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
                     // Set isRecurringCheckBox checked if the expense being edited was a recurring expense
                     isRecurringCheckBox.setSelected(true);}}
         } else if (selectedExpense == null) {
-            JOptionPane.showMessageDialog(this, "Please select an expense you wish to edit.");}
-
-        if (evt.getSource() == categoryCombo) {
+            JOptionPane.showMessageDialog(this, "Please select an expense you wish to edit.");
+        }else if (evt.getSource() == categoryCombo) {
             this.selectedCategory = (String) categoryCombo.getSelectedItem();
         } else if (selectedCategory == null){
             JOptionPane.showMessageDialog(this, "Please select the previous category if you " +
-                "don't wish to edit. Thanks.");}
-
-        if (evt.getSource() == submit) {
+                "don't wish to edit. Thanks.");
+        }else if (evt.getSource() == submit) {
             if (nameInput.getText().isEmpty()) {// Check if user inputs an expense name.
                 JOptionPane.showMessageDialog(this, "Please enter the previous expense name if you " +
                         "don't wish to edit. Thanks.");
             } else if (valueInput.getText().isEmpty()) {// Check if user inputs an expense value.
                 JOptionPane.showMessageDialog(this, "Please enter the previous expense value if you " +
                         "don't wish to edit. Thanks.");
-            } else { try {
-                boolean isRecurring = isRecurringCheckBox.isSelected();
-                ExpenseOD message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(),
-                        selectedCategory, isRecurring, monthID, currSession, selectedExpense);
-                JOptionPane.showMessageDialog(this, message.getMessage());
-                frame.setVisible(false);
-                // Update Month Menu
-                loadMonthMenu(currSession, monthID, null);
-            } catch (EntityException e) {
-                JOptionPane.showMessageDialog(this, "This month does not exist in current " +
-                        "session. Please go to add month page.");}}
+            } else {
+                ExpenseOD message;
+                message = null;
+                try {
+                    boolean isRecurring = isRecurringCheckBox.isSelected();
+                    message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory,
+                            isRecurring, monthID, currSession, selectedExpense);
+                    frame.setVisible(false);
+                    // Update Month Menu
+                    loadMonthMenu(currSession, monthID, null);
+                } catch (EntityException e) {
+                    JOptionPane.showMessageDialog(this, "This month does not exist in current " +
+                        "session. Please go to add month page.");
+                } if (message != null) {
+                JOptionPane.showMessageDialog(this, message.getMessage());}}
         }
     }
 

--- a/src/main/java/views/add_edit_epense_views/EditExpenseV.java
+++ b/src/main/java/views/add_edit_epense_views/EditExpenseV.java
@@ -24,6 +24,7 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
     private final JTextField nameInput;
     private final JTextField valueInput;
     private String selectedExpense;
+    private String selectedCategory;
     private final JCheckBox isRecurringCheckBox = new JCheckBox("Is recurring expense.");
     private final JButton submit = new JButton("Submit");
     private final int monthID;
@@ -90,6 +91,7 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
 
         submit.addActionListener(this);
         expenseCombo.addActionListener(this);
+        categoryCombo.addActionListener(this);
     }
     /**
      * Checks and formats user input to pass in valid parameters to start a use case.
@@ -102,27 +104,36 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
                 if (recurExpense.getName().equals(selectedExpense)) {
                     // Set isRecurringCheckBox checked if the expense being edited was a recurring expense
                     isRecurringCheckBox.setSelected(true);}}
-        }
+        } else if (selectedExpense == null) {
+            JOptionPane.showMessageDialog(this, "Please select an expense you wish to edit.");}
 
-        if(selectedExpense == null){
-            JOptionPane.showMessageDialog( this, "Please select an expense you wish to edit.");
-        }else if(evt.getSource() == submit){
-            String selectedCategory = (String) categoryCombo.getSelectedItem();
-            boolean isRecurring = isRecurringCheckBox.isSelected();
-            ExpenseOD message = null;
-            try {
-                message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory,
-                        isRecurring, monthID, currSession, selectedExpense);
-                // Update Month Menu
+        if (evt.getSource() == categoryCombo) {
+            this.selectedCategory = (String) categoryCombo.getSelectedItem();
+        } else if (selectedCategory == null){
+            JOptionPane.showMessageDialog(this, "Please select the previous category if you " +
+                "don't wish to edit. Thanks.");}
+
+        if (evt.getSource() == submit) {
+            if (nameInput.getText().isEmpty()) {// Check if user inputs an expense name.
+                JOptionPane.showMessageDialog(this, "Please enter the previous expense name if you " +
+                        "don't wish to edit. Thanks.");
+            } else if (valueInput.getText().isEmpty()) {// Check if user inputs an expense value.
+                JOptionPane.showMessageDialog(this, "Please enter the previous expense value if you " +
+                        "don't wish to edit. Thanks.");
+            } else { try {
+                boolean isRecurring = isRecurringCheckBox.isSelected();
+                ExpenseOD message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(),
+                        selectedCategory, isRecurring, monthID, currSession, selectedExpense);
+                JOptionPane.showMessageDialog(this, message.getMessage());
                 frame.setVisible(false);
-                loadMonthMenu(currSession,monthID,null);
+                // Update Month Menu
+                loadMonthMenu(currSession, monthID, null);
             } catch (EntityException e) {
-                JOptionPane.showMessageDialog( this, "This month does not exist in current " +
-                        "session. Please go to add month page.");}
-            if(message != null){
-                JOptionPane.showMessageDialog( this, message.getMessage());}
+                JOptionPane.showMessageDialog(this, "This month does not exist in current " +
+                        "session. Please go to add month page.");}}
         }
     }
+
     /**
      * Load Month Menu and notify user if opening Month Menu of a new MonthlyStorage created.
      *

--- a/src/main/java/views/add_edit_epense_views/EditExpenseV.java
+++ b/src/main/java/views/add_edit_epense_views/EditExpenseV.java
@@ -58,6 +58,14 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
      * Open edit expense GUI.
      */
     public void openEditExpense(){
+        frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
+        frame.setTitle("Edit Expense");
+        frame.setSize(500,300);
+
+        JPanel panel = new JPanel();
+        panel.setBorder(BorderFactory.createEmptyBorder(50, 30, 50, 30));
+        panel.setLayout(new GridLayout(0,1));
+
         JLabel select_expense_label = new JLabel(" Select existing expense:");
         JLabel nameLabel = new JLabel("New Expense Name:");
         JLabel valueLabel = new JLabel(" New Expense Budget:");
@@ -65,18 +73,7 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
         isRecurringCheckBox.setBounds(100,150,50,50);
         submit.setSize(30,10);
 
-        JPanel panel = new JPanel();
-        panel.setBorder(BorderFactory.createEmptyBorder(50, 30, 50, 30));
-        panel.setLayout(new GridLayout(0,1));
-        JPanel panell = new JPanel();
-        panell.setBorder(BorderFactory.createEmptyBorder(50, 30, 50, 30));
-        panell.setLayout(new GridLayout(0,1));
 
-        frame.add(panel, BorderLayout.NORTH);
-        frame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
-        frame.setTitle("Edit Expense");
-        frame.setSize(300,500);
-        frame.setSize(500,300);
         panel.add(select_expense_label);
         panel.add(expenseCombo);
         panel.add(nameLabel, BorderLayout.WEST);
@@ -86,9 +83,9 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
         panel.add(select_category_label);
         panel.add(categoryCombo);
         panel.add(isRecurringCheckBox);
-        frame.add(panell, BorderLayout.SOUTH);
-        panell.add(submit);
+        panel.add(submit);
 
+        frame.add(panel, BorderLayout.NORTH);
         frame.pack();
         frame.setVisible(true);
 
@@ -109,7 +106,10 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
         // Set isRecurringCheckBox checked if the expense being edited was a recurring expense
         this.selectedCategory = (String) categoryCombo.getSelectedItem();
         this.isRecurring = isRecurringCheckBox.isSelected();
-        }else if(evt.getSource() == submit){
+        }else if(expenseCombo.getSelectedIndex() == -1){
+            JOptionPane.showMessageDialog( this, "Please select an expense you wish to edit.");}
+
+        if(evt.getSource() == submit){
             ExpenseOD message = null;
             try {
                 message = controller.expenseInMonth(nameInput.getText(), valueInput.getText(), selectedCategory, isRecurring, monthID, currSession, selectedExpense);
@@ -122,7 +122,6 @@ public class EditExpenseV extends JFrame implements ActionListener, LoadMonthMen
                 JOptionPane.showMessageDialog( this, message.getMessage());}
         }
     }
-
     /**
      * Load Month Menu and notify user if opening Month Menu of a new MonthlyStorage created.
      *

--- a/src/main/java/views/add_edit_epense_views/ExpenseC.java
+++ b/src/main/java/views/add_edit_epense_views/ExpenseC.java
@@ -9,7 +9,7 @@ import use_cases.add_edit_expenses_use_case.ExpenseOD;
 
 public class ExpenseC {
     /**
-     * Expense_Controller passes in user input and produces a Expense_Output_Data Object according to a use case.
+     * Expense_Controller passes in user input and produces an Expense_Output_Data Object according to a use case.
      */
     final ExpenseIB input;
 
@@ -36,6 +36,7 @@ public class ExpenseC {
         if(oldExpense == null){
             return input.addExpenseInMonth(expenseID);
         }
-        else {return input.editExpenseInMonth(expenseID);}
+        else {
+            return input.editExpenseInMonth(expenseID);}
     }
 }

--- a/src/test/java/use_cases/add_edit_category_use_case/CategoryUCITest.java
+++ b/src/test/java/use_cases/add_edit_category_use_case/CategoryUCITest.java
@@ -174,26 +174,6 @@ class CategoryUCITest {
         //Fail to edit Category name when tries to also edit Category budget, but it is a new budget that is a negative number.
         Assertions.assertThrows(NoSuchElementException.class, () -> interactor.findCategory(session.getMonthlyData(9).getCategoryData(), "Banana"));
     }
-
-    /**
-     * Tests fail edit case when user tries to edit a Category that does not exist in MonthlyStorage.
-     * @throws EntityException if a valid method call throws, so that should fail the test
-     */
-    @Test
-    void editCategoryInMonthNoCategoryFail() throws EntityException {
-        CategoryP presenter = new CategoryP();
-        CategoryUCI interactor = new CategoryUCI(presenter);
-        MonthlyStorage monthEdit = new MonthlyStorage(10, 150);
-        session.addMonth(monthEdit);
-
-        CategoryID editIdNegValue = new CategoryID("Banana", 12, 10, session, "Salad");
-
-        // Check if the correct message is returned corresponding to the situation.
-        assertEquals("There is no such category in the current month. Please add a new category or select existing category!", interactor.editCategoryInMonth(editIdNegValue).getMessage());
-        //Fail to edit Category name, but the old_category is not found in MonthlyStorage.
-        Assertions.assertThrows(NoSuchElementException.class, () -> interactor.findCategory(session.getMonthlyData(10).getCategoryData(), "Banana"));
-    }
-
     /**
      * Tests fail edit case when user tries to edit the Category budget into an invalid double.
      * @throws EntityException if a valid method call throws, so that should fail the test

--- a/src/test/java/use_cases/add_edit_expenses_use_case/ExpenseUCITest.java
+++ b/src/test/java/use_cases/add_edit_expenses_use_case/ExpenseUCITest.java
@@ -221,25 +221,6 @@ class ExpenseUCITest {
     }
 
     /**
-     * Tests fail edit case when user tries to edit an Expense that does not exist in MonthlyStorage.
-     */
-    @Test
-    void editExpenseInMonthNoExpenseFail() throws EntityException {
-        SessionStorage session = new SessionStorage();
-        ExpenseP presenter = new ExpenseP();
-        ExpenseUCI interactor = new ExpenseUCI(presenter);
-        MonthlyStorage monthEdit = new MonthlyStorage(10, 150);
-        session.addMonth(monthEdit);
-        monthEdit.addCategory(food);
-
-        ExpenseID editIdNegValue = new ExpenseID("Banana", -3, "Food", false,10, session, "Sandwich");
-        // Check if the correct message is returned corresponding to the situation.
-        assertEquals("There is no such expense in the current month. Please add a new expense or select existing expense!", interactor.editExpenseInMonth(editIdNegValue).getMessage());
-        //Fail to edit Expense name, but the old_expense is not found in MonthlyStorage.
-        Assertions.assertThrows(NoSuchElementException.class, () -> interactor.findExpense(session.getMonthlyData(10).getExpenseData(), "Banana"));
-    }
-
-    /**
      * Tests fail edit case when user tries to edit the Expense value into an invalid double.
      */
     @Test

--- a/src/test/java/use_cases/add_edit_expenses_use_case/ExpenseUCITest.java
+++ b/src/test/java/use_cases/add_edit_expenses_use_case/ExpenseUCITest.java
@@ -162,8 +162,7 @@ class ExpenseUCITest {
         ExpenseID addID = new ExpenseID("Sandwich", 3, "Food", false,7, session, null);
         interactor.addExpenseInMonth(addID);
 
-        ExpenseID editID = new ExpenseID("Sandwich", 5, "Food", false,7, session, "Sandwich");
-        interactor.editExpenseInMonth(editID);
+        ExpenseID editID = new ExpenseID("Sandwich", 5, "Food", false,7, session, addID.getName());
         // Check if the correct message is returned corresponding to the situation.
 
         assertEquals("You have edited an expense!", interactor.editExpenseInMonth(editID).getMessage());
@@ -261,7 +260,7 @@ class ExpenseUCITest {
 
         ExpenseID editID = new ExpenseID("Sandwich", 3, "Other", true,12, session, oldExpense);
         // Check if the correct message is returned corresponding to the situation.
-        assertEquals("You have updated all changes of this new recurring expense!", interactor.editExpenseInMonth(editID).getMessage());
+        assertEquals("You have updated all changes of this recurring expense!", interactor.editExpenseInMonth(editID).getMessage());
         //Expected value is 1 because RecurData is updated with one new recurring expense.
         assertEquals(1, session.getRecurData().size());    }
 


### PR DESCRIPTION
The reason for the unexpected failed messages from failed edits is due to the implementation in the Controllers. 

For example: When a user wishes to edit a category but did not select a category in EditCategoryV, the selected category is null and will rather be classified as an addCategory use case in CategoryC. And a NoSuchElementException would be thrown in CategoryUCI addCategoryInMonth method and is mistaken for a NoSuchElementException thrown in the editCategoryInMonth method. 

Solution: Now this incident is handled in EditCategoryV and is not the responsibility of CategoryUCI. 
(vice versa when a user wishes to edit an expense)